### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/SDL.pm6
+++ b/lib/SDL.pm6
@@ -1,5 +1,4 @@
-
-module SDL;
+unit module SDL;
 
 use NativeCall;
 

--- a/lib/SDL/App.pm6
+++ b/lib/SDL/App.pm6
@@ -1,5 +1,4 @@
-
-module SDL::App;
+unit module SDL::App;
 
 use NativeCall;
 use SDL::Controller;

--- a/lib/SDL/Controller.pm6
+++ b/lib/SDL/Controller.pm6
@@ -1,5 +1,4 @@
-
-module SDL::Controller;
+unit module SDL::Controller;
 
 use NativeCall;
 #use SDL; # I cant do that?

--- a/lib/SDL/Event.pm6
+++ b/lib/SDL/Event.pm6
@@ -1,5 +1,4 @@
-
-module SDL::Event;
+unit module SDL::Event;
 
 use NativeCall; # for CArray type
 

--- a/lib/SDL/Mixer.pm6
+++ b/lib/SDL/Mixer.pm6
@@ -1,5 +1,4 @@
-
-module SDL::Mixer;
+unit module SDL::Mixer;
 
 use NativeCall;
 

--- a/lib/SDL/Mixer/Channels.pm6
+++ b/lib/SDL/Mixer/Channels.pm6
@@ -1,4 +1,4 @@
-module SDL::Mixer::Channels;
+unit module SDL::Mixer::Channels;
 
 use NativeCall;
 

--- a/lib/SDL/Mixer/Effects.pm6
+++ b/lib/SDL/Mixer/Effects.pm6
@@ -1,5 +1,4 @@
-
-module SDL::Mixer::Effects;
+unit module SDL::Mixer::Effects;
 
 use NativeCall;
 

--- a/lib/SDL/Mixer/Samples.pm6
+++ b/lib/SDL/Mixer/Samples.pm6
@@ -1,5 +1,4 @@
-
-module SDL::Mixer::Samples;
+unit module SDL::Mixer::Samples;
 
 use NativeCall;
 

--- a/lib/SDL/Rect.pm6
+++ b/lib/SDL/Rect.pm6
@@ -1,5 +1,4 @@
-
-module SDL::Rect;
+unit module SDL::Rect;
 
 use NativeCall; # for CArray type
 

--- a/lib/SDL/SFont.pm6
+++ b/lib/SDL/SFont.pm6
@@ -1,5 +1,4 @@
-
-module SDL::SFont;
+unit module SDL::SFont;
 
 use NativeCall;
 use SDL::Rect;

--- a/lib/SDL/Surface.pm6
+++ b/lib/SDL/Surface.pm6
@@ -1,5 +1,4 @@
-
-module SDL::Surface;
+unit module SDL::Surface;
 
 use NativeCall;
 use SDL::Rect;

--- a/lib/SDL/Version.pm6
+++ b/lib/SDL/Version.pm6
@@ -1,5 +1,4 @@
-
-module SDL::Version;
+unit module SDL::Version;
 
 #use NativeCall;
 

--- a/lib/SDL/Video.pm6
+++ b/lib/SDL/Video.pm6
@@ -1,5 +1,4 @@
-
-module SDL::Video;
+unit module SDL::Video;
 
 use NativeCall;
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
