### PR TITLE
Fix callback calling syntax in sub arguments

### DIFF
--- a/lib/SDL/Mixer/Channels.pm6
+++ b/lib/SDL/Mixer/Channels.pm6
@@ -6,7 +6,7 @@ use NativeCall;
 # Note: 'is symbol' will be called 'is named' in future
 our sub volume( int, int )                     returns Int  is native('libSDL_mixer')  is symbol('Mix_Volume')            { * }
 our sub allocate( int )                        returns Int  is native('libSDL_mixer')  is symbol('Mix_AllocateChannels')  { * }
-our sub finished( Code &callback(int) )        returns Int  is native('libSDL_mixer')  is symbol('Mix_ChannelFinished')   { * }
+our sub finished( &callback (int) )            returns Int  is native('libSDL_mixer')  is symbol('Mix_ChannelFinished')   { * }
 our sub _play( int, OpaquePointer, int, int )  returns Int  is native('libSDL_mixer')  is symbol('Mix_PlayChannelTimed')  { * }
 our sub halt( int )                            returns Int  is native('libSDL_mixer')  is symbol('Mix_HaltChannel')       { * }
 our sub playing( int )                         returns Int  is native('libSDL_mixer')  is symbol('Mix_Playing')           { * }


### PR DESCRIPTION
In current Rakudo (2015.05) the current code didn't compile anymore, giving
the warning that 'Shape declaration with () is reserved;' and giving the
advice that one should either separate the subarguments with a colon (which
jnthn++ advised to do, however unfortunately didn't allow the code to
compile) or to add a space between the sub-sub-name and its argument.  Also,
having `Code &callback` was a bit doubled-up since the `&callback` was
returning a `Callable` anyway and as it turned out removing the `Code`
modifier allowed the code to compile and the test suite to run all tests bar
one.

If this is not what the original code intended, please let me know and I'll update the PR.
