### PR TITLE
Fix calls to SDL and SDL_mixer libraries

### DIFF
--- a/lib/SDL.pm6
+++ b/lib/SDL.pm6
@@ -49,15 +49,15 @@ such as missing mouse driver when using with framebuffer device. In this case yo
 
 =end pod
 
-our sub init( int32 )             returns Int            is native('libSDL')  is symbol('SDL_Init')            { * }
-our sub init_subsystem( int32 )   returns Int            is native('libSDL')  is symbol('SDL_InitSubSystem')   { * }
-our sub quit_subsystem( int32 )                          is native('libSDL')  is symbol('SDL_QuitSubSystem')   { * }
-our sub was_init( int32 )         returns Int            is native('libSDL')  is symbol('SDL_WasInit')         { * }
-our sub get_ticks( )              returns Int            is native('libSDL')  is symbol('SDL_GetTicks')        { * }
-our sub get_error( )              returns Str            is native('libSDL')  is symbol('SDL_GetError')        { * }
-our sub delay( int32 )                                   is native('libSDL')  is symbol('SDL_Delay')           { * }
-our sub linked_version( )         returns SDL::Version   is native('libSDL')  is symbol('SDL_Linked_Version')  { * }
-our sub rw_from_file( Str, Str )  returns Pointer        is native('libSDL')  is symbol('SDL_RWFromFile')      { * }
+our sub init( int32 )             returns int32          is native('SDL')  is symbol('SDL_Init')            { * }
+our sub init_subsystem( int32 )   returns int32          is native('SDL')  is symbol('SDL_InitSubSystem')   { * }
+our sub quit_subsystem( int32 )                          is native('SDL')  is symbol('SDL_QuitSubSystem')   { * }
+our sub was_init( int32 )         returns int32          is native('SDL')  is symbol('SDL_WasInit')         { * }
+our sub get_ticks( )              returns int32          is native('SDL')  is symbol('SDL_GetTicks')        { * }
+our sub get_error( )              returns Str            is native('SDL')  is symbol('SDL_GetError')        { * }
+our sub delay( int32 )                                   is native('SDL')  is symbol('SDL_Delay')           { * }
+our sub linked_version( )         returns SDL::Version   is native('SDL')  is symbol('SDL_Linked_Version')  { * }
+our sub rw_from_file( Str, Str )  returns Pointer        is native('SDL')  is symbol('SDL_RWFromFile')      { * }
 
 =begin DATA
 our sub init( int32 )		returns Int	is native('libSDL')	is named('SDL_AddTimer')	{ * }

--- a/lib/SDL/Mixer.pm6
+++ b/lib/SDL/Mixer.pm6
@@ -29,5 +29,5 @@ our constant $MUS_MP3      = 6;
 our constant $MUS_MP3_MAD  = 7;
 our constant $MUS_MP3_FLAC = 8;
 
-our sub open_audio( int32, int32, int32, int32 )	returns Int	is native('libSDL_mixer')	is symbol('Mix_OpenAudio')	{ * }
-our sub close_audio( )								returns Int	is native('libSDL_mixer')	is symbol('Mix_CloseAudio')	{ * }
+our sub open_audio( int32, int32, int32, int32 )  returns int32	is native('SDL_mixer')	is symbol('Mix_OpenAudio')	{ * }
+our sub close_audio( )                            returns int32	is native('SDL_mixer')	is symbol('Mix_CloseAudio')	{ * }

--- a/lib/SDL/Mixer/Channels.pm6
+++ b/lib/SDL/Mixer/Channels.pm6
@@ -4,14 +4,14 @@ use NativeCall;
 
 # native calls to libSDL_mixer
 # Note: 'is symbol' will be called 'is named' in future
-our sub volume( int32, int32 )                 returns int32  is native('libSDL_mixer')  is symbol('Mix_Volume')            { * }
-our sub allocate( int32 )                      returns int32  is native('libSDL_mixer')  is symbol('Mix_AllocateChannels')  { * }
-our sub finished( &callback (int32) )          returns int32  is native('libSDL_mixer')  is symbol('Mix_ChannelFinished')   { * }
-our sub _play( int32, Pointer, int32, int32 )  returns int32  is native('libSDL_mixer')  is symbol('Mix_PlayChannelTimed')  { * }
-our sub halt( int32 )                          returns int32  is native('libSDL_mixer')  is symbol('Mix_HaltChannel')       { * }
-our sub playing( int32 )                       returns int32  is native('libSDL_mixer')  is symbol('Mix_Playing')           { * }
-our sub paused( int32 )                        returns int32  is native('libSDL_mixer')  is symbol('Mix_Paused')            { * }
-our sub fading( int32 )                        returns int32  is native('libSDL_mixer')  is symbol('Mix_FadingChannel')     { * }
+our sub volume( int32, int32 )                 returns int32  is native('SDL_mixer')  is symbol('Mix_Volume')            { * }
+our sub allocate( int32 )                      returns int32  is native('SDL_mixer')  is symbol('Mix_AllocateChannels')  { * }
+our sub finished( &callback (int32) )          returns int32  is native('SDL_mixer')  is symbol('Mix_ChannelFinished')   { * }
+our sub _play( int32, Pointer, int32, int32 )  returns int32  is native('SDL_mixer')  is symbol('Mix_PlayChannelTimed')  { * }
+our sub halt( int32 )                          returns int32  is native('SDL_mixer')  is symbol('Mix_HaltChannel')       { * }
+our sub playing( int32 )                       returns int32  is native('SDL_mixer')  is symbol('Mix_Playing')           { * }
+our sub paused( int32 )                        returns int32  is native('SDL_mixer')  is symbol('Mix_Paused')            { * }
+our sub fading( int32 )                        returns int32  is native('SDL_mixer')  is symbol('Mix_FadingChannel')     { * }
 
 # wrappers (for example to support optional parameters)
 # Note: dont use typed parameters here

--- a/lib/SDL/Mixer/Samples.pm6
+++ b/lib/SDL/Mixer/Samples.pm6
@@ -7,5 +7,5 @@ our sub load_WAV( Str $file )  returns Pointer {
     my $rw = rw_from_file( $file, 'rb' );
     return load_WAV_RW( $rw, 1 );
 }
-our sub load_WAV_RW( Pointer, int32 )  returns Pointer  is native('libSDL_mixer')  is symbol('Mix_LoadWAV_RW')  { * }
-our sub rw_from_file( Str, Str )       returns Pointer  is native('libSDL')        is symbol('SDL_RWFromFile')  { * }
+our sub load_WAV_RW( Pointer, int32 )  returns Pointer  is native('SDL_mixer')  is symbol('Mix_LoadWAV_RW')  { * }
+our sub rw_from_file( Str, Str )       returns Pointer  is native('SDL')        is symbol('SDL_RWFromFile')  { * }


### PR DESCRIPTION
It seems that in 6.c there is no longer the need to prefix a library
name with 'lib'; this is prepended automatically.  In other words,
`native('libSDL')` should now be written as `native('SDL')`.  The tests
were complaining about not finding the `liblibSDL` and
`liblibSDL_mixer` libraries, hence this patch.

The compiler also warned not to return `Int` in some cases and that
`int32` should be used instead.  In the places where the compiler was
complaining, the return type has been updated appropriately.

These changes get the core tests working again and the mixer channel
tests at least compiling, however not running completely.  The mixer channel
tests now run about halfway through and fail with a segfault :-/  At which point
I got out of my depth with fixing this module, so thought I'd submit at least
a patch of a partial fix.